### PR TITLE
docs: remove patch- release version from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Find it on Docs.rs: [structopt-derive](https://docs.rs/structopt-derive) and [st
 Add `structopt` and `structopt-derive` to your dependencies of your `Cargo.toml`:
 ```toml
 [dependencies]
-structopt = "0.1.0"
-structopt-derive = "0.1.0"
+structopt = "0.1"
+structopt-derive = "0.1"
 ```
 
 And then, in your rust file:


### PR DESCRIPTION
Users can keep the latest patch release, if they include the version like its mentioned above in the readme.